### PR TITLE
Apply pkcs5 padding even if password len is exact multiple of blocksize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+cmd/carwings/carwings
+.idea

--- a/carwings.go
+++ b/carwings.go
@@ -56,9 +56,7 @@ func encrypt(s, key string) (string, error) {
 	}
 
 	src := []byte(s)
-	if len(src)%cipher.BlockSize() != 0 {
-		src = pkcs5Padding(src, cipher.BlockSize())
-	}
+	src = pkcs5Padding(src, cipher.BlockSize())
 
 	dst := make([]byte, len(src))
 	pos := 0


### PR DESCRIPTION
Looks like the server uses the PHP openssl_decrypt() function which seems
to expect this behaviour.  I can't find any reference as to why openssl is
padding an 8-byte string though :-/ 

Fixes #4 