### PR TITLE
Added additional configuration options...

### DIFF
--- a/carwings.go
+++ b/carwings.go
@@ -18,10 +18,9 @@ import (
 )
 
 const (
-	baseURL = "https://gdcportalgw.its-mo.com/api_v181217_NE/gdc/"
-
-	// Extracted from the NissanConnect EV app
-	initialAppStrings = "geORNtsZe5I4lRGjG9GZiA"
+	// Moved these to vars - we need to continuously update them...
+	//baseURL = "https://gdcportalgw.its-mo.com/api_v181217_NE/gdc/"
+	//initialAppStrings = "geORNtsZe5I4lRGjG9GZiA"
 )
 
 var (
@@ -39,6 +38,10 @@ var (
 
 	// Debug indiciates whether to log HTTP responses to stderr
 	Debug = false
+
+	// Changed from being a constant to make it easier to update/override
+	BaseURL = "https://gdcportalgw.its-mo.com/gworchest_160803EC/gdc/"
+	InitialAppStrings = "geORNtsZe5I4lRGjG9GZiA"
 )
 
 func pkcs5Padding(data []byte, blocksize int) []byte {
@@ -363,10 +366,10 @@ func (r *baseResponse) ErrorMessage() string {
 
 func apiRequest(endpoint string, params url.Values, target response) error {
 	if Debug {
-		fmt.Fprintf(os.Stderr, "POST %s %s\n", baseURL+endpoint, params)
+		fmt.Fprintf(os.Stderr, "POST %s %s\n", BaseURL+endpoint, params)
 	}
 
-	resp, err := http.PostForm(baseURL+endpoint, params)
+	resp, err := http.PostForm(BaseURL+endpoint, params)
 	if err != nil {
 		return err
 	}
@@ -405,7 +408,7 @@ func apiRequest(endpoint string, params url.Values, target response) error {
 // service.
 func (s *Session) Connect(username, password string) error {
 	params := url.Values{}
-	params.Set("initial_app_strings", initialAppStrings)
+	params.Set("initial_app_strings", InitialAppStrings)
 
 	var initResp struct {
 		baseResponse
@@ -437,7 +440,7 @@ func (s *Session) Connect(username, password string) error {
 
 func (s *Session) Login() error {
 	params := url.Values{}
-	params.Set("initial_app_strings", initialAppStrings)
+	params.Set("initial_app_strings", InitialAppStrings)
 
 	params.Set("UserId", s.username)
 	params.Set("Password", s.encpw)

--- a/carwings.go
+++ b/carwings.go
@@ -780,7 +780,9 @@ func (s *Session) ClimateControlStatus() (ClimateStatus, error) {
 	acOn, _ := racr.CruisingRangeAcOn.Float64()
 	acOff, _ := racr.CruisingRangeAcOff.Float64()
 
-	running := racr.RemoteACOperation == "START"
+	// Only accept that climate is running if the response is clear. Otherwise assume not running
+	running := ( ( racr.RemoteACOperation == "START" ) && ( racr.OperationResult != electricWaveAbnormal) );
+
 	acStopTime := time.Time(racr.ACStartStopDateAndTime).In(s.loc)
 	if running {
 		if NotConnected == PluginState(racr.PluginState) {

--- a/carwings.go
+++ b/carwings.go
@@ -41,6 +41,8 @@ var (
 
 	// Changed from being a constant to make it easier to update/override
 	BaseURL = "https://gdcportalgw.its-mo.com/gworchest_160803EC/gdc/"
+
+	// Extracted from the NissanConnect EV app
 	InitialAppStrings = "geORNtsZe5I4lRGjG9GZiA"
 )
 

--- a/cmd/carwings/main.go
+++ b/cmd/carwings/main.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/joeshaw/carwings"
+	"github.com/winterhalder/carwings"
 	"github.com/peterbourgon/ff"
 )
 

--- a/cmd/carwings/main.go
+++ b/cmd/carwings/main.go
@@ -232,7 +232,7 @@ func waitForResult(key string, timeoutSecs uint, poll func(string) (bool, error)
 		if done {
 			break
 		}
-		if time.Since(start) > (time.Second * time.Duration(timeoutSecs) ) {
+		if time.Since(start) > (time.Second * time.Duration(timeoutSecs)) {
 			err = errors.New("timed out waiting for update")
 		}
 		if err != nil {

--- a/cmd/carwings/main.go
+++ b/cmd/carwings/main.go
@@ -17,6 +17,7 @@ import (
 
 type config struct {
 	units string
+	timeoutSecs uint
 }
 
 const (
@@ -59,9 +60,12 @@ func main() {
 	fs := flag.NewFlagSet("carwings", flag.ExitOnError)
 	fs.StringVar(&username, "username", "", "carwings username")
 	fs.StringVar(&password, "password", "", "carwings password")
-	fs.StringVar(&region, "region", carwings.RegionUSA, "carwings region")
+	fs.StringVar(&region, "region", carwings.RegionUSA, "carwings region. Defaults to US (NNA).")
 	fs.StringVar(&sessionFile, "session-file", "~/.carwings-session", "carwings session file")
-	fs.StringVar(&cfg.units, "units", unitsMiles, "units to use (miles or km)")
+	fs.StringVar(&cfg.units, "units", unitsMiles, "units to use (miles or km). Defaults to miles.")
+	fs.StringVar(&carwings.BaseURL, "url", "https://gdcportalgw.its-mo.com/api_v181217_NE/gdc/", "base carwings api endpoint to use")
+	fs.StringVar(&carwings.InitialAppStrings, "ias", "geORNtsZe5I4lRGjG9GZiA", "carwings initial app strings")
+	fs.UintVar(&cfg.timeoutSecs, "timeout", 60, "timeout in seconds (defaults to 60)")
 	fs.BoolVar(&carwings.Debug, "debug", false, "debug mode")
 	fs.Usage = usage(fs)
 
@@ -217,7 +221,7 @@ func metersToUnits(units string, meters int) float64 {
 }
 
 // waitForResult will poll using the supplied method until either success or error
-func waitForResult(key string, poll func(string) (bool, error)) error {
+func waitForResult(key string, timeoutSecs uint, poll func(string) (bool, error)) error {
 	// All requests take more than 3 seconds, so wait this before even trying
 	time.Sleep(3 * time.Second)
 
@@ -228,7 +232,7 @@ func waitForResult(key string, poll func(string) (bool, error)) error {
 		if done {
 			break
 		}
-		if time.Since(start) > time.Minute {
+		if time.Since(start) > (time.Second * time.Duration(timeoutSecs) ) {
 			err = errors.New("timed out waiting for update")
 		}
 		if err != nil {
@@ -250,8 +254,8 @@ func runUpdate(s *carwings.Session, cfg config, args []string) error {
 		return err
 	}
 
-	fmt.Print("Waiting for update to complete... ")
-	return waitForResult(key, s.CheckUpdate)
+	fmt.Print("Waiting for update to complete (" + fmt.Sprint(cfg.timeoutSecs) + " seconds)... ")
+	return waitForResult(key, cfg.timeoutSecs, s.CheckUpdate)
 }
 
 func runBattery(s *carwings.Session, cfg config, args []string) error {
@@ -337,7 +341,7 @@ func runClimateOff(s *carwings.Session, cfg config, args []string) error {
 	}
 
 	fmt.Print("Waiting for climate control update to complete... ")
-	err = waitForResult(key, s.CheckClimateOffRequest)
+	err = waitForResult(key, cfg.timeoutSecs, s.CheckClimateOffRequest)
 	if err == nil {
 		fmt.Println("Climate control turned on")
 	}
@@ -353,7 +357,7 @@ func runClimateOn(s *carwings.Session, cfg config, args []string) error {
 	}
 
 	fmt.Print("Waiting for climate control update to complete... ")
-	err = waitForResult(key, s.CheckClimateOnRequest)
+	err = waitForResult(key, cfg.timeoutSecs, s.CheckClimateOnRequest)
 
 	if err == nil {
 		fmt.Println("Climate control turned on")
@@ -369,8 +373,8 @@ func runLocate(s *carwings.Session, cfg config, args []string) error {
 		return err
 	}
 
-	fmt.Print("Waiting for location update to complete... ")
-	err = waitForResult(key, s.CheckLocateRequest)
+	fmt.Print("Waiting for location update to complete (" + fmt.Sprint(cfg.timeoutSecs) + " seconds)... ")
+	err = waitForResult(key, cfg.timeoutSecs, s.CheckLocateRequest)
 	if err != nil {
 		return err
 	}

--- a/cmd/carwings/server.go
+++ b/cmd/carwings/server.go
@@ -10,7 +10,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/joeshaw/carwings"
+	"github.com/winterhalder/carwings"
 )
 
 func updateLoop(ctx context.Context, s *carwings.Session) {


### PR DESCRIPTION
I'm in Canada, and had to override some constants to get things to work. Thought it might be helpful if these were part of the configuration options instead of requiring folks to rebuilt.

The new options are:
- timeout - timeout in seconds (60 seconds is way to short for access from Canada unfortunately). I set mine to 600!
- url - the baseurl to use. I've been using https://gdcportalgw.its-mo.com/gworchest_160803EC/gdc/
- intialappstrings - I haven't had to change that one, but seemed like a good addition for completeness
