### PR TITLE
Monthly stats modifications - fixes #13

### DIFF
--- a/cmd/carwings/main.go
+++ b/cmd/carwings/main.go
@@ -427,7 +427,7 @@ func runMonthly(s *carwings.Session, cfg config, args []string) error {
 		}
 		if distance > 0 {
 			fmt.Println("          =======  =======")
-			efficiency := (power / metersToUnits(cfg.units, distance)) / 10
+			efficiency := (power / metersToUnits(cfg.units, distance)) / 1000
 			fmt.Printf("          %5.1f%s %5.1f %-10.10s\n\n",
 				metersToUnits(cfg.units, distance), cfg.units, efficiency, ms.EfficiencyScale)
 		}

--- a/cmd/carwings/main.go
+++ b/cmd/carwings/main.go
@@ -406,7 +406,7 @@ func runMonthly(s *carwings.Session, cfg config, args []string) error {
 	fmt.Printf("Monthly Driving Statistics for %s\n", time.Now().Local().Format("January 2006"))
 	fmt.Printf("  Driving efficiency: %.4f %s over %s in %d trips\n",
 		ms.Total.Efficiency*1000, ms.EfficiencyScale, prettyUnits(cfg.units, ms.Total.MetersTravelled), ms.Total.Trips)
-	fmt.Printf("  Driving cost: %.4f at a rate of %.4f/kWh for %.1fkWh => %.4f/%s\n",
+	fmt.Printf("  Driving cost: %.4f at a rate of %.4f/kWh for %.1f kWh => %.4f/%s\n",
 		ms.ElectricityBill, ms.ElectricityRate, ms.Total.PowerConsumed, ms.ElectricityBill/metersToUnits(cfg.units, ms.Total.MetersTravelled), cfg.units)
 	fmt.Println()
 
@@ -422,14 +422,14 @@ func runMonthly(s *carwings.Session, cfg config, args []string) error {
 			distance += t.Meters
 			power += t.PowerConsumedTotal
 
-			fmt.Printf("    %5s %s %5.1f %-10.10s\n", t.Started.Local().Format("15:04"),
-				prettyUnits(cfg.units, t.Meters), t.Efficiency, ms.EfficiencyScale)
+			fmt.Printf("    %5s %6.1f %s %5.1f %-10.10s %6.1f kWh\n", t.Started.Local().Format("15:04"),
+				metersToUnits(cfg.units, t.Meters), cfg.units, t.Efficiency, ms.EfficiencyScale, t.PowerConsumedTotal/1000)
 		}
 		if distance > 0 {
-			fmt.Println("          =======  =======")
+			fmt.Println("          ============ ============== ============")
 			efficiency := (power / metersToUnits(cfg.units, distance)) / 1000
-			fmt.Printf("          %5.1f%s %5.1f %-10.10s\n\n",
-				metersToUnits(cfg.units, distance), cfg.units, efficiency, ms.EfficiencyScale)
+			fmt.Printf("          %6.1f %s %5.1f %-10.10s %6.1f kWh\n\n",
+				metersToUnits(cfg.units, distance), cfg.units, efficiency, ms.EfficiencyScale, power/1000)
 		}
 	}
 


### PR DESCRIPTION
Includes:-

- Fix for the units in monthly stats
- Improvements in monthly stats outputs

These improvements include making the trip distance output be 1 decimal place resolution rather than truncate to integer, and making the formatting more tabular.  Additionally added power usage per trip and per day.

This changes the output from:-

```
Monthly Driving Statistics for July 2019
  Driving efficiency: 0.2300 kWh/mile over 274 miles in 23 trips
  Driving cost: 6.9034 at a rate of 0.1100/kWh for 62.8kWh => 0.0252/miles

  Trips on 2019-07-01 Monday
    06:58 25 miles   0.3 kWh/mile
    12:55 0 miles   0.3 kWh/mile
    17:38 27 miles   0.2 kWh/mile
          =======  =======
           52.9miles  23.6 kWh/mile
```

to 

```
Monthly Driving Statistics for July 2019
  Driving efficiency: 0.2300 kWh/mile over 274 miles in 23 trips
  Driving cost: 6.9034 at a rate of 0.1100/kWh for 62.8 kWh => 0.0252/miles

  Trips on 2019-07-01 Monday
    06:58   25.1 miles   0.3 kWh/mile      6.5 kWh
    12:55    0.3 miles   0.3 kWh/mile      0.1 kWh
    17:38   27.4 miles   0.2 kWh/mile      5.9 kWh
          ============ ============== ==============
            52.9 miles   0.2 kWh/mile     12.5 kWh
```
