### PR TITLE
Fix #37

### DIFF
--- a/carwings.go
+++ b/carwings.go
@@ -660,7 +660,7 @@ func (s *Session) BatteryStatus() (BatteryStatus, error) {
 			BatteryChargingStatus     string
 			BatteryCapacity           int `json:",string"`
 			BatteryRemainingAmount    string
-			BatteryRemainingAmountWH  int `json:",string"`
+			BatteryRemainingAmountWH  string
 			BatteryRemainingAmountKWH string
 			SOC                       struct {
 				Value int `json:",string"`
@@ -702,6 +702,7 @@ func (s *Session) BatteryStatus() (BatteryStatus, error) {
 	}
 
 	remaining, _ := strconv.Atoi(batrec.BatteryStatus.BatteryRemainingAmount)
+	remainingWH, _ := strconv.Atoi(batrec.BatteryStatus.BatteryRemainingAmountWH)
 	acOn, _ := batrec.CruisingRangeAcOn.Float64()
 	acOff, _ := batrec.CruisingRangeAcOff.Float64()
 
@@ -714,7 +715,7 @@ func (s *Session) BatteryStatus() (BatteryStatus, error) {
 		Timestamp:          time.Time(batrec.NotificationDateAndTime).In(s.loc),
 		Capacity:           batrec.BatteryStatus.BatteryCapacity,
 		Remaining:          remaining,
-		RemainingWH:        batrec.BatteryStatus.BatteryRemainingAmountWH,
+		RemainingWH:        remainingWH,
 		StateOfCharge:      soc,
 		CruisingRangeACOn:  int(acOn),
 		CruisingRangeACOff: int(acOff),


### PR DESCRIPTION
fixes #37 

As described in #37 the `BatteryRemainingAmountWH` of `BatteryStatus` may be an empty string which results in an error when the carwings response is unmarshaled. By parsing the string externally parsing the error is dropped and `remainigWH` is set to zero in case of an empty string.