### PR TITLE
Fix units on monthly report

### DIFF
--- a/cmd/carwings/main.go
+++ b/cmd/carwings/main.go
@@ -486,17 +486,17 @@ func runMonthly(s *carwings.Session, cfg config, args []string) error {
 
 			fmt.Printf("    %5s %6.1f %s %5.1f %s %6.1f kWh\n", t.Started.Local().Format("15:04"),
 				metersToUnits(cfg.units, t.Meters), cfg.units,
-				efficiencyToUnits("kWh/km", cfg.effunits, t.Efficiency),
+				efficiencyToUnits(ms.EfficiencyScale, cfg.effunits, t.Efficiency),
 				cfg.effunits, t.PowerConsumedTotal/1000)
 		}
 		if distance > 0 {
 			fmt.Printf("          =======%.*s ======%.*s ==========\n",
 				len(cfg.units), "====",
 				len(cfg.effunits), "=========")
-			efficiency := (power / metersToUnits(cfg.units, distance)) / 1000
+			efficiency := power / float64(distance)     // in Wh/m or kWh/km
 			fmt.Printf("          %6.1f %s %5.1f %s %6.1f kWh\n\n",
 				metersToUnits(cfg.units, distance), cfg.units,
-				efficiencyToUnits(ms.EfficiencyScale, cfg.effunits, efficiency),
+				efficiencyToUnits("kWh/km", cfg.effunits, efficiency),
 				cfg.effunits, power/1000)
 		}
 	}


### PR DESCRIPTION
Fixes #42

For the individual trips, the code was assuming that "ElectricMileage"
was in kWh/km but for me it seems to be kWh/mile. The json record provides a
field "ElectricCostScale" which for me is "kWh/mile" so assume
this specifies the units of "ElectricMileage".

For the per-day summary, it had the opposite problem - it calculated
the per-day summary in display units, but then assumed this matches
ms.EfficiencyScale units.