### PR TITLE
Enforce User-Agent header to be set

### DIFF
--- a/carwings.go
+++ b/carwings.go
@@ -383,7 +383,7 @@ func apiRequest(endpoint string, params url.Values, target response) error {
 		return err
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Set("User-Agent", "")
+	req.Header.Set("User-Agent", "CW")
 
 	if Debug {
 		body, err := httputil.DumpRequestOut(req, true)


### PR DESCRIPTION
Fixes the "404 (INVALID PARAMS) error" during login.  Fixes #53